### PR TITLE
[dynatrace/v1] Redact token in error log

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
@@ -200,7 +200,8 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
         }
         catch (Throwable e) {
             if (logger.isErrorEnabled()) {
-                logger.error("failed to create custom metric in Dynatrace: " + customMetric.getMetricId(), redactToken(e));
+                logger.error("failed to create custom metric in Dynatrace: " + customMetric.getMetricId(),
+                        redactToken(e));
             }
         }
     }
@@ -282,10 +283,12 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
     }
 
     /**
-     * Redacts the API token from a thrown exception before printing the exception message.
+     * Redacts the API token from a thrown exception before printing the exception
+     * message.
      * @param t the original {@link Throwable}
-     * @return the original {@link Throwable} if it does not contain the API token or a new {@link Throwable} with the
-     *  message with the token redacted and same stack trace as the original Throwable.
+     * @return the original {@link Throwable} if it does not contain the API token or a
+     * new {@link Throwable} with the message with the token redacted and same stack trace
+     * as the original Throwable.
      */
     private Throwable redactToken(Throwable t) {
         if (!t.getMessage().contains(config.apiToken())) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
@@ -291,7 +291,7 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
      * as the original Throwable.
      */
     private Throwable redactToken(Throwable t) {
-        if (!t.getMessage().contains(config.apiToken())) {
+        if (t.getMessage() != null && !t.getMessage().contains(config.apiToken())) {
             return t;
         }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
@@ -386,7 +386,7 @@ class DynatraceExporterV1Test {
     }
 
     @Test
-    void testTokenShouldBeRedactedInPut() {
+    void testTokenShouldBeRedactedInPutFailure() {
         HttpSender httpClient = spy(HttpSender.class);
 
         String invalidUrl = "http://localhost###";
@@ -396,7 +396,7 @@ class DynatraceExporterV1Test {
 
         meterRegistry.gauge("my.gauge", GAUGE_VALUE);
         Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        // first export fails on creation
+
         exporter.export(Collections.singletonList(gauge));
 
         assertThat(LOGGER.getLogEvents())
@@ -408,7 +408,7 @@ class DynatraceExporterV1Test {
     }
 
     @Test
-    void testTokenShouldBeRedactedInPost() throws Throwable {
+    void testTokenShouldBeRedactedInPostFailure() throws Throwable {
         HttpSender httpClient = spy(HttpSender.class);
 
         String invalidUrl = "http://localhost###";
@@ -423,13 +423,13 @@ class DynatraceExporterV1Test {
 
         meterRegistry.gauge("my.gauge", GAUGE_VALUE);
         Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        // first export fails on creation
+
         exporter.export(Collections.singletonList(gauge));
 
         assertThat(LOGGER.getLogEvents())
                 // map to only keep the message strings
                 .extracting(LogEvent::getMessage).containsExactly(
-                        // the custom metric was created, meaning the PUT call succeded
+                        // the custom metric was created, meaning the PUT call succeeded
                         "created custom:my.gauge as custom metric in Dynatrace",
                         // the POST call now threw, and the token is redacted.
                         String.format(

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
@@ -16,7 +16,6 @@
 package io.micrometer.dynatrace.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.common.util.internal.logging.LogEvent;
 import io.micrometer.common.util.internal.logging.MockLogger;
 import io.micrometer.common.util.internal.logging.MockLoggerFactory;
 import io.micrometer.core.instrument.*;

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
@@ -16,6 +16,7 @@
 package io.micrometer.dynatrace.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.common.util.internal.logging.LogEvent;
 import io.micrometer.common.util.internal.logging.MockLogger;
 import io.micrometer.common.util.internal.logging.MockLoggerFactory;
 import io.micrometer.core.instrument.*;
@@ -40,8 +41,7 @@ import java.util.stream.Stream;
 import static io.micrometer.common.util.internal.logging.InternalLogLevel.DEBUG;
 import static io.micrometer.common.util.internal.logging.InternalLogLevel.ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
@@ -386,25 +386,110 @@ class DynatraceExporterV1Test {
     }
 
     @Test
-    void testTokenShouldBeRedacted() throws Throwable {
-        HttpSender httpClient = mock(HttpSender.class);
-        HttpSender.Request.Builder builder = HttpSender.Request.build("https://localhost", httpClient);
-        when(httpClient.send(isA(HttpSender.Request.class))).thenReturn(new HttpSender.Response(200, null));
+    void testTokenShouldBeRedactedInPut() {
+        HttpSender httpClient = spy(HttpSender.class);
 
-        String invalidUrl = "http://localhost";
+        String invalidUrl = "http://localhost###";
         String apiToken = "this.is.a.fake.apiToken";
 
-        String exceptionTextPattern = "Mocked exception with API token %s contained in it";
+        DynatraceExporterV1 exporter = getDynatraceExporterV1(httpClient, invalidUrl, apiToken);
 
-        when(httpClient.put(anyString()))
-                // throw on the first try
-                .thenThrow(new IllegalArgumentException(String.format(exceptionTextPattern, apiToken)))
-                // succeed the second time
-                .thenReturn(builder);
+        meterRegistry.gauge("my.gauge", GAUGE_VALUE);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        // first export fails on creation
+        exporter.export(Collections.singletonList(gauge));
 
-        when(httpClient.post(anyString()))
-                .thenThrow(new IllegalArgumentException(String.format(exceptionTextPattern, apiToken)));
+        assertThat(LOGGER.getLogEvents())
+                // map to only keep the message strings
+                .extracting(LogEvent::getMessage)
+                .containsExactly(String.format(
+                        "failed to build request: Illegal character in fragment at index 17: %s/api/v1/timeseries/custom:my.gauge?api-token=<redacted>",
+                        invalidUrl));
+    }
 
+    @Test
+    void testTokenShouldBeRedactedInPost() throws Throwable {
+        HttpSender httpClient = spy(HttpSender.class);
+
+        String invalidUrl = "http://localhost###";
+        String apiToken = "this.is.a.fake.apiToken";
+
+        HttpSender.Request.Builder builder = HttpSender.Request.build("http://localhost", httpClient);
+        // mock the PUT call, so we can even run the post call.
+        doReturn(builder).when(httpClient).put(anyString());
+        doReturn(new HttpSender.Response(200, "")).when(httpClient).send(any(HttpSender.Request.class));
+
+        DynatraceExporterV1 exporter = getDynatraceExporterV1(httpClient, invalidUrl, apiToken);
+
+        meterRegistry.gauge("my.gauge", GAUGE_VALUE);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        // first export fails on creation
+        exporter.export(Collections.singletonList(gauge));
+
+        assertThat(LOGGER.getLogEvents())
+                // map to only keep the message strings
+                .extracting(LogEvent::getMessage).containsExactly(
+                        // the custom metric was created, meaning the PUT call succeded
+                        "created custom:my.gauge as custom metric in Dynatrace",
+                        // the POST call now threw, and the token is redacted.
+                        String.format(
+                                "failed to build request: Illegal character in fragment at index 17: %s/api/v1/entity/infrastructure/custom/?api-token=<redacted>",
+                                invalidUrl));
+    }
+
+    @Test
+    void trySendHttpRequestSuccess() throws Throwable {
+        HttpSender httpClient = mock(HttpSender.class);
+        DynatraceExporterV1 exporter = FACTORY.injectLogger(() -> createExporter(httpClient));
+        HttpSender.Request.Builder reqBuilder = mock(HttpSender.Request.Builder.class);
+
+        // simulate a success response
+        when(reqBuilder.send()).thenReturn(new HttpSender.Response(200, ""));
+
+        // test that everything works and no error is logged
+        exporter.trySendHttpRequest(reqBuilder);
+        verify(reqBuilder).send();
+        assertThat(LOGGER.getLogEvents()).isEmpty();
+    }
+
+    @Test
+    void trySendHttpRequestErrorCode() throws Throwable {
+        HttpSender httpClient = mock(HttpSender.class);
+        DynatraceExporterV1 exporter = FACTORY.injectLogger(() -> createExporter(httpClient));
+        HttpSender.Request.Builder reqBuilder = mock(HttpSender.Request.Builder.class);
+
+        // simulate a failure response. This should be accepted, it will be handled
+        // elsewhere
+        when(reqBuilder.send()).thenReturn(new HttpSender.Response(400, ""));
+
+        // test that everything works and no error is logged
+        exporter.trySendHttpRequest(reqBuilder);
+        verify(reqBuilder).send();
+        assertThat(LOGGER.getLogEvents()).isEmpty();
+    }
+
+    @Test
+    void trySendHttpRequestThrowsAndRedacts() throws Throwable {
+        HttpSender httpClient = mock(HttpSender.class);
+        String apiToken = "this.is.a.fake.apiToken";
+        DynatraceExporterV1 exporter = getDynatraceExporterV1(httpClient, "http://localhost", apiToken);
+
+        HttpSender.Request.Builder reqBuilder = mock(HttpSender.Request.Builder.class);
+
+        // simulate that the request builder throws. This should not happen if the
+        // endpoint is invalid,
+        // as the URI is validated elsewhere.
+        String exceptionMessageTemplate = "Exception with the token: %s";
+        when(reqBuilder.send()).thenThrow(new Throwable(String.format(exceptionMessageTemplate, apiToken)));
+
+        exporter.trySendHttpRequest(reqBuilder);
+        verify(reqBuilder).send();
+        // assert that an error is logged
+        assertThat(LOGGER.getLogEvents()).hasSize(1).extracting(x -> x.getMessage()).containsExactlyInAnyOrder(
+                "failed to send metrics to Dynatrace: " + String.format(exceptionMessageTemplate, "<redacted>"));
+    }
+
+    private DynatraceExporterV1 getDynatraceExporterV1(HttpSender httpClient, String url, String apiToken) {
         DynatraceExporterV1 exporter = FACTORY.injectLogger(() -> new DynatraceExporterV1(new DynatraceConfig() {
             @Override
             public String get(String key) {
@@ -418,37 +503,10 @@ class DynatraceExporterV1Test {
 
             @Override
             public String uri() {
-                return invalidUrl;
+                return url;
             }
         }, clock, httpClient));
-
-        meterRegistry.gauge("my.gauge", GAUGE_VALUE);
-        Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        // first export fails on creation
-        exporter.export(Collections.singletonList(gauge));
-        // second exports succeeds on creation but fails on export
-        exporter.export(Collections.singletonList(gauge));
-
-        // check that the methods were called once
-        verify(httpClient, times(2)).put(anyString());
-        verify(httpClient).post(anyString());
-
-        assertThat(LOGGER.getLogEvents())
-                // filter for log events that have a cause (these are the ones with
-                // exceptions)
-                .filteredOn(x -> x.getCause() != null)
-                // get the exception message
-                .extracting(x -> x.getCause().getMessage())
-                // The cause on the exception has the redacted token
-                .contains(String.format(exceptionTextPattern, "<redacted>"))
-                // There is no cause on an exception that has the token in it.
-                .doesNotContain(String.format(exceptionTextPattern, apiToken));
-
-        assertThat(LOGGER.getLogEvents())
-                // stringify objects
-                .extracting(x -> x.toString())
-                // ensure the API token appears nowhere
-                .noneMatch(x -> x.contains(apiToken));
+        return exporter;
     }
 
     private DynatraceExporterV1 createExporter(HttpSender httpClient) {


### PR DESCRIPTION
In the (legacy) Dynatrace exporter v1, if an invalid URL is passed, the exception thrown by the String->URL conversion can contain the API token, since it is specified as part of the URL. Upon error logging, this can lead to the token being written to the logs. This PR adds a method that scrubs the token from the thrown exception before printing it. 