### PR TITLE
Switch to primitive types and ensure synchronization

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -64,16 +64,34 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
         summary.recordNonNegative(amount);
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public long count() {
         return summary.getCount();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double totalAmount() {
         return summary.getTotal();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double max() {
         return summary.getMax();

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -98,11 +98,10 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
     }
 
     /**
-     * @deprecated since 1.9.10.
-     * Using this method is not synchronized and might give inconsistent results when
-     * multiple getters are called sequentially. It is recommended to
-     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
-     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     * @deprecated since 1.9.10. Using this method is not synchronized and might give
+     * inconsistent results when multiple getters are called sequentially. It is
+     * recommended to {@link DynatraceDistributionSummary#takeSummarySnapshot() take a
+     * snapshot} and use the getters on the {@link DynatraceSummarySnapshot} instead.
      */
     @Deprecated
     public double min() {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -97,6 +97,14 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
         return summary.getMax();
     }
 
+    /**
+     * @deprecated since 1.9.10.
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
+    @Deprecated
     public double min() {
         return summary.getMin();
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -63,7 +63,7 @@ final class DynatraceSummary {
 
     DynatraceSummarySnapshot takeSummarySnapshot() {
         synchronized (this) {
-            return new DynatraceSummarySnapshot(getMin(), getMax(), getTotal(), getCount());
+            return new DynatraceSummarySnapshot(min, max, total, count);
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -45,18 +45,34 @@ final class DynatraceSummary {
         }
     }
 
+    /**
+     * Getters are not synchronized and might give inconsistent results. It is recommended
+     * to take a snapshot and use the {@link DynatraceSummarySnapshot} instead.
+     */
     long getCount() {
         return count;
     }
 
+    /**
+     * Getters are not synchronized and might give inconsistent results. It is recommended
+     * to take a snapshot and use the {@link DynatraceSummarySnapshot} instead.
+     */
     double getTotal() {
         return total;
     }
 
+    /**
+     * Getters are not synchronized and might give inconsistent results. It is recommended
+     * to take a snapshot and use the {@link DynatraceSummarySnapshot} instead.
+     */
     double getMin() {
         return min;
     }
 
+    /**
+     * Getters are not synchronized and might give inconsistent results. It is recommended
+     * to take a snapshot and use the {@link DynatraceSummarySnapshot} instead.
+     */
     double getMax() {
         return max;
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -37,6 +37,8 @@ final class DynatraceSummary {
 
         synchronized (this) {
             max = Math.max(max, amount);
+            // check if count is equal to 0 and set initial min value if it is, otherwise
+            // min will always stay at 0.
             min = count > 0 ? Math.min(min, amount) : amount;
             total += amount;
             count++;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -44,27 +44,19 @@ final class DynatraceSummary {
     }
 
     long getCount() {
-        synchronized (this) {
-            return count;
-        }
+        return count;
     }
 
     double getTotal() {
-        synchronized (this) {
-            return total;
-        }
+        return total;
     }
 
     double getMin() {
-        synchronized (this) {
-            return min;
-        }
+        return min;
     }
 
     double getMax() {
-        synchronized (this) {
-            return max;
-        }
+        return max;
     }
 
     DynatraceSummarySnapshot takeSummarySnapshot() {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -138,11 +138,11 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
     }
 
     /**
-     * @deprecated since 1.9.10.
-     * Using this method is not synchronized and might give inconsistent results when
-     * multiple getters are called sequentially. It is recommended to
-     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
-     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     * @deprecated since 1.9.10. Using this method is not synchronized and might give
+     * inconsistent results when multiple getters are called sequentially. It is
+     * recommended to {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit)
+     * take a snapshot} and use the getters on the {@link DynatraceSummarySnapshot}
+     * instead.
      */
     @Deprecated
     public double min(TimeUnit unit) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -104,11 +104,23 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
         summary.recordNonNegative(inBaseUnit);
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public long count() {
         return summary.getCount();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double totalTime(TimeUnit unit) {
         return unit.convert((long) summary.getTotal(), baseTimeUnit());

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -126,11 +126,25 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
         return unit.convert((long) summary.getTotal(), baseTimeUnit());
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double max(TimeUnit unit) {
         return unit.convert((long) summary.getMax(), baseTimeUnit());
     }
 
+    /**
+     * @deprecated since 1.9.10.
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
+    @Deprecated
     public double min(TimeUnit unit) {
         return unit.convert((long) summary.getMin(), baseTimeUnit());
     }

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
@@ -99,7 +99,7 @@ class DynatraceSummaryTest {
             }
         });
 
-        // second executor records the max 100 times
+        // third executor records the max 100 times
         executorService.submit(() -> {
             for (int i = 0; i < valueRecordedNTimes; i++) {
                 summary.recordNonNegative(expMax);

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
@@ -18,6 +18,10 @@ package io.micrometer.dynatrace.types;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 /**
@@ -71,12 +75,51 @@ class DynatraceSummaryTest {
         assertMinMaxSumCount(summary, 0.123, 8.93, 16.953, 4);
     }
 
+    @Test
+    void testConcurrentAdds() throws InterruptedException {
+        DynatraceSummary summary = new DynatraceSummary();
+
+        int valueRecordedNTimes = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        double expMin = 1.234;
+        double expMax = 123.456;
+        double expAvg = (expMin + expMax) / 2;
+
+        // first executor adds the min 100 times
+        executorService.submit(() -> {
+            for (int i = 0; i < valueRecordedNTimes; i++) {
+                summary.recordNonNegative(expMin);
+            }
+        });
+
+        // second executor records the avg 100 times
+        executorService.submit(() -> {
+            for (int i = 0; i < valueRecordedNTimes; i++) {
+                summary.recordNonNegative(expAvg);
+            }
+        });
+
+        // second executor records the max 100 times
+        executorService.submit(() -> {
+            for (int i = 0; i < valueRecordedNTimes; i++) {
+                summary.recordNonNegative(expMax);
+            }
+        });
+
+        executorService.shutdown();
+        boolean terminated =
+            executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        assertThat(terminated).isTrue();
+
+        double expTotal = (valueRecordedNTimes * expMin) + (valueRecordedNTimes * expAvg) + (valueRecordedNTimes * expMax);
+        assertMinMaxSumCount(summary, expMin, expMax, expTotal, 300);
+    }
+
     private void assertMinMaxSumCount(DynatraceSummary summary, Double expMin, Double expMax, Double expTotal,
-            long expCount) {
+                                      long expCount) {
         assertThat(summary.getMin()).isCloseTo(expMin, OFFSET);
         assertThat(summary.getMax()).isCloseTo(expMax, OFFSET);
         assertThat(summary.getCount()).isEqualTo(expCount);
         assertThat(summary.getTotal()).isCloseTo(expTotal, OFFSET);
     }
-
 }

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
@@ -107,19 +107,20 @@ class DynatraceSummaryTest {
         });
 
         executorService.shutdown();
-        boolean terminated =
-            executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        boolean terminated = executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
         assertThat(terminated).isTrue();
 
-        double expTotal = (valueRecordedNTimes * expMin) + (valueRecordedNTimes * expAvg) + (valueRecordedNTimes * expMax);
+        double expTotal = (valueRecordedNTimes * expMin) + (valueRecordedNTimes * expAvg)
+                + (valueRecordedNTimes * expMax);
         assertMinMaxSumCount(summary, expMin, expMax, expTotal, 300);
     }
 
     private void assertMinMaxSumCount(DynatraceSummary summary, Double expMin, Double expMax, Double expTotal,
-                                      long expCount) {
+            long expCount) {
         assertThat(summary.getMin()).isCloseTo(expMin, OFFSET);
         assertThat(summary.getMax()).isCloseTo(expMax, OFFSET);
         assertThat(summary.getCount()).isEqualTo(expCount);
         assertThat(summary.getTotal()).isCloseTo(expTotal, OFFSET);
     }
+
 }


### PR DESCRIPTION
Presumably due to the numeric instability of the DoubleAdder, we have seen cases in which the Min and Max did not represent a consistent value when compared to the sum stored in the DoubleAdder. Given that the addition and snapshotting of values are already `synchronized`, this PR removes the used atomic tracking instruments and replaces them with primitive types. 