### PR TITLE
Ensure LongTaskTimer and FunctionTimer produce consistent data

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -302,15 +302,8 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toFunctionTimerLine(FunctionTimer meter) {
-        double count = 0;
-        double total = 0;
-
-        // This should ensure that no function timer values can be added while values are
-        // read, leading to an invalid intermediate state.
-        synchronized (meter) {
-            count = meter.count();
-            total = meter.totalTime(getBaseTimeUnit());
-        }
+        double count = meter.count();
+        double total = meter.totalTime(getBaseTimeUnit());
 
         long countLong = (long) count;
 
@@ -318,9 +311,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             logger.debug("Timer with 0 count dropped: {}", meter.getId().getName());
             return Stream.empty();
         }
+        else if (countLong == 1) {
+            return createSummaryLine(meter, total, total, total, 1);
+        }
 
-        double average = total / count;
-
+        double average = total / countLong;
         return createSummaryLine(meter, average, average, total, countLong);
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -16,8 +16,8 @@
 package io.micrometer.dynatrace.v2;
 
 import com.dynatrace.metric.util.*;
-import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.util.StringUtils;
@@ -60,13 +60,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static final Pattern IS_NULL_ERROR_RESPONSE = Pattern.compile("\"error\":\\s?null");
 
     private static final WarnThenDebugLogger stackTraceWarnThenDebugLogger = new WarnThenDebugLogger(
-            DynatraceExporterV2.class);
+        DynatraceExporterV2.class);
 
     private static final WarnThenDebugLogger nanGaugeWarnThenDebugLogger = new WarnThenDebugLogger(
-            DynatraceExporterV2.class);
+        DynatraceExporterV2.class);
 
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source",
-            "micrometer");
+        "micrometer");
 
     // This should be non-static for MockLoggerFactory.injectLogger() in tests.
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
@@ -93,8 +93,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         try {
             // noinspection ResultOfMethodCallIgnored
             URI.create(uri).toURL();
-        }
-        catch (IllegalArgumentException | MalformedURLException ex) {
+        } catch (IllegalArgumentException | MalformedURLException ex) {
             return false;
         }
 
@@ -108,7 +107,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         if (config.uri().equals(DynatraceMetricApiConstants.getDefaultOneAgentEndpoint())) {
             logger
                 .warn("Potential misconfiguration detected: Token is provided, but the endpoint is set to the local OneAgent endpoint, "
-                        + "thus the token will be ignored. If exporting to the cluster API endpoint is intended, its URI has to be provided explicitly.");
+                    + "thus the token will be ignored. If exporting to the cluster API endpoint is intended, its URI has to be provided explicitly.");
             return true;
         }
         return false;
@@ -128,8 +127,9 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
      * API will be dropped and not exported. If the number of serialized data points
      * exceeds the maximum number of allowed data points per request they will be sent in
      * chunks.
+     *
      * @param meters A list of {@link Meter Meters} that are serialized as one or more
-     * metric lines.
+     *               metric lines.
      */
     @Override
     public void export(List<Meter> meters) {
@@ -158,8 +158,8 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private Stream<String> toMetricLines(Meter meter) {
         return meter.match(this::toGaugeLine, this::toCounterLine, this::toTimerLine, this::toDistributionSummaryLine,
-                this::toLongTaskTimerLine, this::toTimeGaugeLine, this::toFunctionCounterLine,
-                this::toFunctionTimerLine, this::toMeterLine);
+            this::toLongTaskTimerLine, this::toTimeGaugeLine, this::toFunctionCounterLine,
+            this::toFunctionTimerLine, this::toMeterLine);
     }
 
     Stream<String> toGaugeLine(Gauge meter) {
@@ -182,13 +182,12 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 // on the client side here will not change the metrics in Dynatrace.
 
                 nanGaugeWarnThenDebugLogger.log(() -> String.format(
-                        "Meter '%s' returned a value of NaN, which will not be exported. This can be a deliberate value or because the weak reference to the backing object expired.",
-                        meter.getId().getName()));
+                    "Meter '%s' returned a value of NaN, which will not be exported. This can be a deliberate value or because the weak reference to the backing object expired.",
+                    meter.getId().getName()));
                 return null;
             }
             return createMetricBuilder(meter).setDoubleGaugeValue(value).serialize();
-        }
-        catch (MetricException e) {
+        } catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
@@ -202,8 +201,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private String createCounterLine(Meter meter, Measurement measurement) {
         try {
             return createMetricBuilder(meter).setDoubleCounterValueDelta(measurement.getValue()).serialize();
-        }
-        catch (MetricException e) {
+        } catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
@@ -251,8 +249,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         try {
             String line = createMetricBuilder(meter).setDoubleSummaryValue(min, max, total, count).serialize();
             return Stream.of(line);
-        }
-        catch (MetricException e) {
+        } catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
@@ -277,7 +274,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         HistogramSnapshot snapshot = meter.takeSnapshot();
 
         long count = snapshot.count();
-            if (count == 0) {
+        if (count == 0) {
             return Stream.empty();
         } else if (count == 1) {
             // in cases where the snapshot has only one value, often the min/max and sum are not the same
@@ -301,15 +298,26 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toFunctionTimerLine(FunctionTimer meter) {
-        long count = (long) meter.count();
-        if (count < 1) {
+        double count = 0;
+        double total = 0;
+
+        // This should ensure that no function timer values can be added while values are read, leading to an
+        // invalid intermediate state.
+        synchronized (meter) {
+            count = meter.count();
+            total = meter.totalTime(getBaseTimeUnit());
+        }
+
+        long countLong = (long) count;
+
+        if (countLong < 1) {
             logger.debug("Timer with 0 count dropped: {}", meter.getId().getName());
             return Stream.empty();
         }
-        double total = meter.totalTime(getBaseTimeUnit());
-        double average = meter.mean(getBaseTimeUnit());
 
-        return createSummaryLine(meter, average, average, total, count);
+        double average = total / count;
+
+        return createSummaryLine(meter, average, average, total, countLong);
     }
 
     Stream<String> toMeterLine(Meter meter) {
@@ -329,7 +337,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private DimensionList fromTags(List<Tag> tags) {
         return DimensionList.fromCollection(
-                tags.stream().map(tag -> Dimension.create(tag.getKey(), tag.getValue())).collect(Collectors.toList()));
+            tags.stream().map(tag -> Dimension.create(tag.getKey(), tag.getValue())).collect(Collectors.toList()));
     }
 
     private <T> Stream<T> streamOf(Iterable<T> iterable) {
@@ -359,12 +367,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 .send()
                 .onSuccess(response -> handleSuccess(lineCount, response))
                 .onError(response -> logger.error("Failed metric ingestion: Error Code={}, Response Body={}",
-                        response.code(), getTruncatedBody(response)));
-        }
-        catch (Throwable throwable) {
+                    response.code(), getTruncatedBody(response)));
+        } catch (Throwable throwable) {
             logger.warn("Failed metric ingestion: " + throwable);
             stackTraceWarnThenDebugLogger.log("Stack trace for previous 'Failed metric ingestion' warning log: ",
-                    throwable);
+                throwable);
         }
     }
 
@@ -379,21 +386,18 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 Matcher linesInvalidMatchResult = EXTRACT_LINES_INVALID.matcher(response.body());
                 if (linesOkMatchResult.find() && linesInvalidMatchResult.find()) {
                     logger.debug("Sent {} metric lines, linesOk: {}, linesInvalid: {}.", totalSent,
-                            linesOkMatchResult.group(1), linesInvalidMatchResult.group(1));
-                }
-                else {
+                        linesOkMatchResult.group(1), linesInvalidMatchResult.group(1));
+                } else {
                     logger.warn("Unable to parse response: {}", getTruncatedBody(response));
                 }
-            }
-            else {
+            } else {
                 logger.warn("Unable to parse response: {}", getTruncatedBody(response));
             }
-        }
-        else {
+        } else {
             // common pitfall if URI is supplied in V1 format (without endpoint path)
             logger.error(
-                    "Expected status code 202, got {}.\nResponse Body={}\nDid you specify the ingest path (e.g.: /api/v2/metrics/ingest)?",
-                    response.code(), getTruncatedBody(response));
+                "Expected status code 202, got {}.\nResponse Body={}\nDid you specify the ingest path (e.g.: /api/v2/metrics/ingest)?",
+                response.code(), getTruncatedBody(response));
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -262,7 +262,7 @@ class DynatraceExporterV2Test {
     }
 
     @Test
-    void toFunctionTimerLineShouldDropNanMean() {
+    void toFunctionTimerLineShouldDropNanTotal() {
         FunctionTimer functionTimer = new FunctionTimer() {
             @Override
             public double count() {
@@ -272,7 +272,7 @@ class DynatraceExporterV2Test {
             @Override
             @SuppressWarnings("NullableProblems")
             public double totalTime(TimeUnit unit) {
-                return 5000;
+                return NaN;
             }
 
             @Override
@@ -287,11 +287,6 @@ class DynatraceExporterV2Test {
                 return new Id("my.functionTimer", Tags.empty(), null, null, Type.TIMER);
             }
 
-            @Override
-            @SuppressWarnings("NullableProblems")
-            public double mean(TimeUnit unit) {
-                return NaN;
-            }
         };
 
         assertThat(exporter.toFunctionTimerLine(functionTimer)).isEmpty();

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -18,6 +18,7 @@ package io.micrometer.dynatrace.v2;
 import com.dynatrace.file.util.DynatraceFileBasedConfigurationProvider;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.lang.Nullable;
 import io.micrometer.core.util.internal.logging.LogEvent;
@@ -36,6 +37,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -344,6 +348,110 @@ class DynatraceExporterV2Test {
         assertThat(lines.get(0)).isEqualTo(
                 "my.longTaskTimer,dt.metrics.source=micrometer gauge,min=2000.0,max=48000.0,sum=236000.0,count=11 "
                         + clock.wallTime());
+    }
+
+    private static void busyWait(LongTaskTimer ltt) {
+        ltt.record(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        });
+    }
+
+    @Test
+    void longTaskTimerWithSingleValueExportsConsistentData() throws InterruptedException {
+        // In the past, there were problems with the LongTaskTimer:
+        // In cases where only one value was exported, the max and duration were read sequentially
+        // while the clock continued to tick in the background.
+        // Since the Dynatrace API checks this data strictly, data where the sum and max were not exactly
+        // the same when the count was 1 were rejected.
+        // The discrepancy is only caused by the non-atomicity of retrieving max and sum.
+        // As soon as there is more than 1 observation, this problem should disappear since
+        // the Dynatrace API checks for min <= mean <= max, and that should always be the case
+        // when there is more than 1 value. If it is not the case, the underlying data collection
+        // is really broken.
+
+        // Therefore, for this test we need to use the system clock.
+        Clock clock = Clock.SYSTEM;
+        DynatraceConfig config = createDefaultDynatraceConfig();
+        DynatraceMeterRegistry registry = DynatraceMeterRegistry.builder(config).clock(clock).build();
+        DynatraceExporterV2 exporter = new DynatraceExporterV2(config, clock, httpClient);
+
+        LongTaskTimer ltt = LongTaskTimer.builder("my.ltt").register(registry);
+
+        // This will run in the background until it is interrupted down below.
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(()-> busyWait(ltt));
+
+        // wait for a little bit to ensure there is something to measure
+        Thread.sleep(500);
+
+        List<String> lines = exporter.toLongTaskTimerLine(ltt).collect(Collectors.toList());
+
+        // export complete, can shut down active background thread.
+        executorService.shutdownNow();
+
+        // assertions
+        assertThat(lines).hasSize(1);
+
+        // A String[]: "min=1", "max=1", "sum=1", "count=1"
+        String[] gaugeComponents = lines.get(0).split(" ")[1].split(",");
+        // trim the "min=", "max=", etc. prefixes and keep only the string representations of the values.
+        String min = gaugeComponents[1].split("=")[1];
+        String max = gaugeComponents[2].split("=")[1];
+        String sum = gaugeComponents[3].split("=")[1];
+        String count = gaugeComponents[4].split("=")[1];
+
+        assertThat(min)
+            .isEqualTo(sum)
+            .isEqualTo(max);
+
+        assertThat(count).isEqualTo("1");
+    }
+
+    @Test
+    void longTaskTimerWithMultipleValuesExportsConsistentData() throws InterruptedException {
+        // For this test we need to use the system clock. See longTaskTimerWithSingleValueExportsConsistentData for
+        // more info
+        Clock clock = Clock.SYSTEM;
+        DynatraceConfig config = createDefaultDynatraceConfig();
+        DynatraceMeterRegistry registry = DynatraceMeterRegistry.builder(config).clock(clock).build();
+        DynatraceExporterV2 exporter = new DynatraceExporterV2(config, clock, httpClient);
+
+        LongTaskTimer ltt = LongTaskTimer.builder("my.ltt").register(registry);
+
+        // This will run in the background until it is interrupted down below.
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.submit(() -> busyWait(ltt));
+        Thread.sleep(500);
+        executorService.submit(() -> busyWait(ltt));
+
+        Thread.sleep(500);
+
+        List<String> lines = exporter.toLongTaskTimerLine(ltt).collect(Collectors.toList());
+
+        // export complete, can shut down active background thread.
+        executorService.shutdownNow();
+
+        // assertions
+        assertThat(lines).hasSize(1);
+
+        // A String[]: "min=1", "max=1", "sum=1", "count=1"
+        String[] gaugeComponents = lines.get(0).split(" ")[1].split(",");
+        // trim the "min=", "max=", etc. prefixes and keep only the string representations of the values.
+
+        double min = Double.parseDouble(gaugeComponents[1].split("=")[1]);
+        double max = Double.parseDouble(gaugeComponents[2].split("=")[1]);
+        double sum = Double.parseDouble(gaugeComponents[3].split("=")[1]);
+        int count = Integer.parseInt(gaugeComponents[4].split("=")[1]);
+        double mean = sum/count;
+
+        assertThat(min).isLessThanOrEqualTo(mean);
+        assertThat(mean).isLessThanOrEqualTo(max);
+        assertThat(count).isEqualTo(2);
     }
 
     @Test

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -365,8 +365,13 @@ class DynatraceExporterV2Test {
         // of retrieving max and sum. As soon as there is more than 1 observation, this
         // problem should disappear since the Dynatrace API checks for min <= mean <= max,
         // and that should always be the case when there is more than 1 value. If it is
-        // not the case, the underlying data collection is really broken.// Therefore, for
-        // this test we need to use the system clock.
+        // not the case, the underlying data collection is really broken. For example, we
+        // saw this issue with the metric 'http.server.requests.active', when there was
+        // exactly one request in-flight. The retrieval of max and total are not
+        // synchronized, so the clock continues to tick and results in two different
+        // values (e.g., max=0.764418,sum=0.700539,count=1, which is invalid according to
+        // the Dynatrace specification). Therefore, for this test we need to use the
+        // system clock.
         Clock clock = Clock.SYSTEM;
         DynatraceConfig config = createDefaultDynatraceConfig();
         DynatraceMeterRegistry registry = DynatraceMeterRegistry.builder(config).clock(clock).build();

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -431,7 +431,7 @@ class DynatraceExporterV2Test {
         // assertions
         assertThat(lines).hasSize(1);
 
-        // A String[]: "min=1", "max=1", "sum=1", "count=1"
+        // A String[]: "min=x", "max=x", "sum=x", "count=x"
         String[] gaugeComponents = lines.get(0).split(" ")[1].split(",");
 
         // trim the "min=", "max=", etc. prefixes and keep only the string representations


### PR DESCRIPTION
Due to non-atomic reads for LongTaskTimer, there was a discrepancy between sum and max in exports where exactly 1 task was running, which was then rejected by the Dynatrace API. This fixes exports for a single value. For FunctionTimers, I don't think this problem has been recorded before, but due to the non-atomic read operation, it is still possible to record a new function timer invocation while the data is read from the Meter. This PR also fixes that. 